### PR TITLE
Parse images from a stream

### DIFF
--- a/src/Pfim/dds/Dds.cs
+++ b/src/Pfim/dds/Dds.cs
@@ -39,6 +39,20 @@ namespace Pfim
         public static Dds Create(Stream stream, PfimConfig config)
         {
             DdsHeader header = new DdsHeader(stream);
+            return DecodeDds(stream, config, header);
+        }
+
+        /// <summary>
+        /// Same as a regular create except assumes that the magic number has already been consumed
+        /// </summary>
+        internal static IImage CreateSkipMagic(Stream stream, PfimConfig config)
+        {
+            DdsHeader header = new DdsHeader(stream, true);
+            return DecodeDds(stream, config, header);
+        }
+
+        private static Dds DecodeDds(Stream stream, PfimConfig config, DdsHeader header)
+        {
             Dds dds;
             switch (header.PixelFormat.FourCC)
             {

--- a/src/Pfim/targa/Targa.cs
+++ b/src/Pfim/targa/Targa.cs
@@ -40,7 +40,19 @@ namespace Pfim
         public static Targa Create(Stream str, PfimConfig config)
         {
             var header = new TargaHeader(str);
-            var targa = (header.IsCompressed) ? (IDecodeTarga)(new CompressedTarga())
+            return DecodeTarga(str, config, header);
+        }
+
+        internal static IImage CreateWithPartialHeader(Stream str, PfimConfig config, byte[] magic)
+        {
+            var header = new TargaHeader(str, magic);
+            return DecodeTarga(str, config, header);
+        }
+
+        private static Targa DecodeTarga(Stream str, PfimConfig config, TargaHeader header)
+        {
+            var targa = (header.IsCompressed)
+                ? (IDecodeTarga) (new CompressedTarga())
                 : new UncompressedTarga();
 
             byte[] data;

--- a/tests/Pfim.Tests/ImageTests.cs
+++ b/tests/Pfim.Tests/ImageTests.cs
@@ -52,9 +52,7 @@ namespace Pfim.Tests
         {
             var data = File.ReadAllBytes(Path.Combine("data", path));
             var image = Pfim.FromFile(Path.Combine("data", path));
-            var image2 = Path.GetExtension(path).ToLower() == ".dds"
-                ? (IImage)Dds.Create(data, new PfimConfig())
-                : Targa.Create(data, new PfimConfig());
+            var image2 = Pfim.FromStream(new MemoryStream(data), new PfimConfig());
             image.ApplyColorMap();
             image2.ApplyColorMap();
             Assert.Equal(format, image.Format);


### PR DESCRIPTION
- Parse images from a stream using `Pfim.FromStream`
- Detects image format by file magic number. If DDS's is not seen, move onto Targa (which doesn't have a magic number).
- This PR also changes the parsing of images from files away from file name extension, and towards the new stream detection.

Ref: #43 #44