### PR TITLE
Throw when invalid targa image type detected

### DIFF
--- a/src/Pfim/targa/TargaHeader.cs
+++ b/src/Pfim/targa/TargaHeader.cs
@@ -110,6 +110,11 @@ namespace Pfim
             IDLength = buf[0];
             HasColorMap = buf[1] == 1;
             ImageType = (TargaImageType) buf[2];
+            if (!Enum.IsDefined(typeof(TargaImageType), ImageType))
+            {
+                throw new ArgumentException("Detected invalid targa image");
+            }
+
             ColorMapOrigin = BitConverter.ToInt16(buf, 3);
             ColorMapLength = BitConverter.ToInt16(buf, 5);
             ColorMapDepthBits = buf[7];

--- a/tests/Pfim.Tests/TargaTests.cs
+++ b/tests/Pfim.Tests/TargaTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Xunit;
 using System.IO;
+using System.Text;
 
 namespace Pfim.Tests
 {
@@ -315,6 +316,14 @@ namespace Pfim.Tests
             {
                 Assert.Equal(0, image.Data[i + 3]);
             }
+        }
+
+        [Fact]
+        public void InvalidTargaException()
+        {
+            var data = Encoding.ASCII.GetBytes("Hello world! A wonderful evening");
+            var ex = Assert.ThrowsAny<Exception>(() => Pfim.FromStream(new MemoryStream(data)));
+            Assert.Equal("Detected invalid targa image", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Now that targa is the fallback decoder when dds in not recognized, more
"bad" input is likely, so this check will try and detect earlier in the
decode process if the input is actually a targa image