### PR TITLE
Amoritize allocations across image decodes

### DIFF
--- a/src/Pfim.Benchmarks/DdsBenchmark.cs
+++ b/src/Pfim.Benchmarks/DdsBenchmark.cs
@@ -2,6 +2,7 @@
 using BenchmarkDotNet.Attributes;
 using FreeImageAPI;
 using ImageMagick;
+using Pfim.Tests;
 using DS = DevILSharp;
 
 namespace Pfim.Benchmarks
@@ -14,7 +15,7 @@ namespace Pfim.Benchmarks
 
         private byte[] data;
 
-        private readonly PfimConfig _pfimConfig = new PfimConfig();
+        private readonly PfimConfig _pfimConfig = new PfimConfig(allocator: new PfimAllocator());
 
         [GlobalSetup]
         public void SetupData()
@@ -24,7 +25,13 @@ namespace Pfim.Benchmarks
         }
 
         [Benchmark]
-        public IImage Pfim() => Dds.Create(data, _pfimConfig);
+        public int Pfim()
+        {
+            using (var image = Dds.Create(data, _pfimConfig))
+            {
+                return image.BytesPerPixel;
+            }
+        }
 
         [Benchmark]
         public FreeImageBitmap FreeImage() => FreeImageAPI.FreeImageBitmap.FromStream(new MemoryStream(data));

--- a/src/Pfim.Benchmarks/Pfim.Benchmarks.csproj
+++ b/src/Pfim.Benchmarks/Pfim.Benchmarks.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="ImageFormats" Version="1.0.0" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.4.3" />
     <PackageReference Include="StbSharp" Version="0.6.8.33" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,6 +23,7 @@
     <None CopyToOutputDirectory="Always" Include="..\..\lib\FreeImage.dll" />
     <Compile Include="..\..\lib\TargaImage.cs" />
     <Compile Include="..\..\lib\TGASharpLib.cs" Link="TGASharpLib.cs" />
+    <Compile Include="..\..\tests\Pfim.Tests\PfimAllocator.cs" Link="PfimAllocator.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Pfim/DefaultAllocator.cs
+++ b/src/Pfim/DefaultAllocator.cs
@@ -1,0 +1,14 @@
+﻿namespace Pfim
+{
+    class DefaultAllocator : IImageAllocator
+    {
+        public byte[] Rent(int size)
+        {
+            return new byte[size];
+        }
+
+        public void Return(byte[] data)
+        {
+        }
+    }
+}

--- a/src/Pfim/IImage.cs
+++ b/src/Pfim/IImage.cs
@@ -1,12 +1,20 @@
-﻿namespace Pfim
+﻿using System;
+
+namespace Pfim
 {
     /// <summary>
     /// Defines a common interface that all images are decoded into
     /// </summary>
-    public interface IImage
+    public interface IImage : IDisposable
     {
         /// <summary>The raw data</summary>
         byte[] Data { get; }
+
+        /// <summary>
+        /// Length of the raw data. Unless decoding with a custom allocator
+        /// this will be equivalent to `Data.Length`
+        /// </summary>
+        int DataLen { get; }
 
         /// <summary>Width of the image in pixels</summary>
         int Width { get; }

--- a/src/Pfim/IImageAllocator.cs
+++ b/src/Pfim/IImageAllocator.cs
@@ -1,0 +1,17 @@
+﻿namespace Pfim
+{
+    public interface IImageAllocator
+    {
+        /// <summary>
+        /// Allocate a buffer that is used during image decoding. All buffers
+        /// allocated with rent will be returned once the image is disposed.
+        /// Length of returned data can exceed size requested.
+        /// </summary>
+        byte[] Rent(int size);
+
+        /// <summary>
+        /// Returns a buffer to the pool that was previously obtained by rent.
+        /// </summary>
+        void Return(byte[] data);
+    }
+}

--- a/src/Pfim/PfimConfig.cs
+++ b/src/Pfim/PfimConfig.cs
@@ -5,43 +5,40 @@
         public PfimConfig(
             int bufferSize = 0x8000,
             TargetFormat targetFormat = TargetFormat.Native,
-            bool decompress = true)
+            bool decompress = true,
+            IImageAllocator allocator = null)
         {
+            Allocator = allocator ?? new DefaultAllocator();
             BufferSize = bufferSize;
             TargetFormat = targetFormat;
             Decompress = decompress;
         }
 
+        public IImageAllocator Allocator { get; }
         public int BufferSize { get; }
         public TargetFormat TargetFormat { get; }
         public bool Decompress { get; }
 
         public override bool Equals(object obj)
         {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            return obj.GetType() == this.GetType() && Equals((PfimConfig) obj);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((PfimConfig) obj);
         }
 
         protected bool Equals(PfimConfig other)
         {
-            return BufferSize == other.BufferSize && TargetFormat == other.TargetFormat && Decompress == other.Decompress;
+            return Equals(Allocator, other.Allocator) && BufferSize == other.BufferSize && TargetFormat == other.TargetFormat && Decompress == other.Decompress;
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = BufferSize;
-                hashCode = (hashCode * 397) ^ TargetFormat.GetHashCode();
+                var hashCode = (Allocator != null ? Allocator.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ BufferSize;
+                hashCode = (hashCode * 397) ^ (int) TargetFormat;
                 hashCode = (hashCode * 397) ^ Decompress.GetHashCode();
                 return hashCode;
             }
@@ -49,7 +46,7 @@
 
         public override string ToString()
         {
-            return $"{nameof(BufferSize)}: {BufferSize}, {nameof(TargetFormat)}: {TargetFormat}, {nameof(Decompress)}: {Decompress}";
+            return $"{nameof(Allocator)}: {Allocator}, {nameof(BufferSize)}: {BufferSize}, {nameof(TargetFormat)}: {TargetFormat}, {nameof(Decompress)}: {Decompress}";
         }
     }
 }

--- a/src/Pfim/dds/Bc5Dds.cs
+++ b/src/Pfim/dds/Bc5Dds.cs
@@ -5,7 +5,7 @@
         private readonly byte[] _firstGradient = new byte[8];
         private readonly byte[] _secondGradient = new byte[8];
 
-        public Bc5Dds(DdsHeader header) : base(header)
+        public Bc5Dds(DdsHeader header, PfimConfig config) : base(header, config)
         {
         }
 

--- a/src/Pfim/dds/DdsHeaderDxt10.cs
+++ b/src/Pfim/dds/DdsHeaderDxt10.cs
@@ -33,24 +33,24 @@ namespace Pfim
             }
         }
 
-        internal Dds NewDecoder(DdsHeader header)
+        internal Dds NewDecoder(DdsHeader header, PfimConfig config)
         {
             switch (DxgiFormat)
             {
                 case DxgiFormat.BC1_TYPELESS:
                 case DxgiFormat.BC1_UNORM_SRGB:
                 case DxgiFormat.BC1_UNORM:
-                    return new Dxt1Dds(header);
+                    return new Dxt1Dds(header, config);
 
                 case DxgiFormat.BC3_TYPELESS:
                 case DxgiFormat.BC3_UNORM:
                 case DxgiFormat.BC3_UNORM_SRGB:
-                    return new Dxt3Dds(header);
+                    return new Dxt3Dds(header, config);
 
                 case DxgiFormat.BC5_SNORM:
                 case DxgiFormat.BC5_TYPELESS:
                 case DxgiFormat.BC5_UNORM:
-                    return new Dxt5Dds(header);
+                    return new Dxt5Dds(header, config);
 
                 case DxgiFormat.R8G8B8A8_TYPELESS:
                 case DxgiFormat.R8G8B8A8_UNORM:
@@ -58,11 +58,11 @@ namespace Pfim
                 case DxgiFormat.R8G8B8A8_UINT:
                 case DxgiFormat.R8G8B8A8_SNORM:
                 case DxgiFormat.R8G8B8A8_SINT:
-                    return new UncompressedDds(header, 32, true);
+                    return new UncompressedDds(header, config, 32, true);
                 case DxgiFormat.B8G8R8A8_TYPELESS:
                 case DxgiFormat.B8G8R8A8_UNORM:
                 case DxgiFormat.B8G8R8A8_UNORM_SRGB:
-                    return new UncompressedDds(header, 32, false);
+                    return new UncompressedDds(header, config, 32, false);
 
                 case DxgiFormat.UNKNOWN:
                 case DxgiFormat.R32G32B32A32_TYPELESS:

--- a/src/Pfim/dds/Dxt1Dds.cs
+++ b/src/Pfim/dds/Dxt1Dds.cs
@@ -5,7 +5,7 @@
         private const int PIXEL_DEPTH = 3;
         private const int DIV_SIZE = 4;
 
-        public Dxt1Dds(DdsHeader header) : base(header)
+        public Dxt1Dds(DdsHeader header, PfimConfig config) : base(header, config)
         {
         }
 

--- a/src/Pfim/dds/Dxt3Dds.cs
+++ b/src/Pfim/dds/Dxt3Dds.cs
@@ -11,7 +11,7 @@
         public override int BitsPerPixel => PIXEL_DEPTH * 8;
         public override ImageFormat Format => ImageFormat.Rgba32;
 
-        public Dxt3Dds(DdsHeader header) : base(header)
+        public Dxt3Dds(DdsHeader header, PfimConfig config) : base(header, config)
         {
         }
 

--- a/src/Pfim/dds/Dxt5Dds.cs
+++ b/src/Pfim/dds/Dxt5Dds.cs
@@ -15,7 +15,7 @@ namespace Pfim
         protected override byte DivSize => DIV_SIZE;
         protected override byte CompressedBytesPerBlock => 16;
 
-        public Dxt5Dds(DdsHeader header) : base(header)
+        public Dxt5Dds(DdsHeader header, PfimConfig config) : base(header, config)
         {
         }
 

--- a/tests/Pfim.Tests/PfimAllocator.cs
+++ b/tests/Pfim.Tests/PfimAllocator.cs
@@ -1,0 +1,25 @@
+﻿using System.Buffers;
+using System.Threading;
+
+namespace Pfim.Tests
+{
+    class PfimAllocator : IImageAllocator
+    {
+        private int _rented;
+        private readonly ArrayPool<byte> _shared = ArrayPool<byte>.Shared;
+
+        public byte[] Rent(int size)
+        {
+            Interlocked.Increment(ref _rented);
+            return _shared.Rent(size);
+        }
+
+        public void Return(byte[] data)
+        {
+            Interlocked.Decrement(ref _rented);
+            _shared.Return(data);
+        }
+
+        public int Rented => _rented;
+    }
+}

--- a/tests/Pfim.Tests/UtilTests.cs
+++ b/tests/Pfim.Tests/UtilTests.cs
@@ -10,7 +10,7 @@ namespace Pfim.Tests
         {
             byte[] buf = { 1, 2, 3, 4, 5 };
             var mem = new MemoryStream();
-            var actual = Util.Translate(mem, buf, 0);
+            var actual = Util.Translate(mem, buf, buf.Length, 0);
             Assert.Equal(5, actual);
         }
 
@@ -19,7 +19,7 @@ namespace Pfim.Tests
         {
             byte[] buf = { 1, 2, 3, 4, 5 };
             var mem = new MemoryStream(new byte[] { 100 });
-            var actual = Util.Translate(mem, buf, 1);
+            var actual = Util.Translate(mem, buf, buf.Length, 1);
             Assert.Equal(5, actual);
             Assert.Equal(new byte[] { 2, 3, 4, 5, 100 }, buf);
         }
@@ -29,7 +29,7 @@ namespace Pfim.Tests
         {
             byte[] buf = { 1, 2, 3, 4, 5 };
             var mem = new MemoryStream();
-            var actual = Util.Translate(mem, buf, 1);
+            var actual = Util.Translate(mem, buf, buf.Length, 1);
             Assert.Equal(4, actual);
             Assert.Equal(new byte[] { 2, 3, 4, 5, 5 }, buf);
         }
@@ -39,7 +39,7 @@ namespace Pfim.Tests
         {
             byte[] buf = { 1, 2, 3, 4, 5 };
             var mem = new MemoryStream(new byte[] { 100, 99, 98, 97 });
-            var actual = Util.Translate(mem, buf, 4);
+            var actual = Util.Translate(mem, buf, buf.Length, 4);
             Assert.Equal(5, actual);
             Assert.Equal(new byte[] { 5, 100, 99, 98, 97 }, buf);
         }
@@ -49,7 +49,7 @@ namespace Pfim.Tests
         {
             byte[] buf = { 1, 2, 3, 4, 5 };
             var mem = new MemoryStream();
-            var actual = Util.Translate(mem, buf, 4);
+            var actual = Util.Translate(mem, buf, buf.Length, 4);
             Assert.Equal(1, actual);
             Assert.Equal(new byte[] { 5, 2, 3, 4, 5 }, buf);
         }
@@ -59,7 +59,7 @@ namespace Pfim.Tests
         {
             byte[] data = new byte[5];
             var mem = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
-            Util.FillBottomLeft(mem, data, 1, 1);
+            Util.FillBottomLeft(mem, data, data.Length, 1, 1);
             Assert.Equal(new byte[] { 5, 4, 3, 2, 1 }, data);
         }
 
@@ -68,7 +68,7 @@ namespace Pfim.Tests
         {
             byte[] data = new byte[6];
             var mem = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6 });
-            Util.FillBottomLeft(mem, data, 2, 2);
+            Util.FillBottomLeft(mem, data, data.Length, 2, 2);
             Assert.Equal(new byte[] { 5, 6, 3, 4, 1, 2 }, data);
         }
 
@@ -77,7 +77,7 @@ namespace Pfim.Tests
         {
             byte[] data = new byte[5];
             var mem = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
-            Util.FillBottomLeft(mem, data, 1, 1);
+            Util.FillBottomLeft(mem, data, data.Length, 1, 1);
             Assert.Equal(new byte[] { 5, 4, 3, 2, 1 }, data);
         }
 
@@ -86,7 +86,7 @@ namespace Pfim.Tests
         {
             byte[] data = new byte[6];
             var mem = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6 });
-            Util.FillBottomLeft(mem, data, 2, 2);
+            Util.FillBottomLeft(mem, data, data.Length, 2, 2);
             Assert.Equal(new byte[] { 5, 6, 3, 4, 1, 2 }, data);
         }
 
@@ -95,7 +95,7 @@ namespace Pfim.Tests
         {
             byte[] data = new byte[6];
             var mem = new MemoryStream(new byte[] { 1, 2, 3, 4 });
-            Util.FillBottomLeft(mem, data, 2, 3);
+            Util.FillBottomLeft(mem, data, data.Length, 2, 3);
             Assert.Equal(new byte[] { 3, 4, 0, 1, 2, 0 }, data);
         }
 


### PR DESCRIPTION
Ref #47

Introduces `IImageAllocator` to `PfimConfig` which allows one to supply a custom allocation strategy (buffer pooling, etc) for image data and other byte buffers. The default behavior is no buffer pooling.

As a result of pooling buffers, an `IImage` implements `IDisposable` so that one can return any buffers to a pool. If one is using the default behavior, disposing is not necessary but good practice.

The `IImageAllactor` may allocate an array larger than what was asked for. This necessitated a new property: `DataLen` which is the length of the pixel data (anything after `Image.Data[Image.DataLen - 1]` should be considered undefined). One should no longer use `Image.Data.Length`. `Image.Data.Length` was not used as much as `Image.Height` and `Image.Stride` when creating an image, so hopefully this won't cause too big of an issue.

Performance improvement is varied (ranging from minor degradation to 3x decrease in mean time to decode).

Future enhancement: creating a `detach` function that will signal to Pfim not to dispose of the data buffer. This will allow users which pass pixel data around and keep it independent of the lifetime of an `IImage`