### PR TITLE
Apply colormap by default

### DIFF
--- a/src/Pfim.Viewer.Forms/Form1.cs
+++ b/src/Pfim.Viewer.Forms/Form1.cs
@@ -30,7 +30,6 @@ namespace Pfim.Viewer.Forms
             }
 
             var image = Pfim.FromFile(dialog.FileName);
-            image.ApplyColorMap();
 
             PixelFormat format;
             switch (image.Format)
@@ -79,6 +78,8 @@ namespace Pfim.Viewer.Forms
             var ptr = Marshal.UnsafeAddrOfPinnedArrayElement(image.Data, 0);
             var bitmap = new Bitmap(image.Width, image.Height, image.Stride, format, ptr);
 
+            // While frameworks like WPF and ImageSharp natively understand 8bit gray values.
+            // WinForms can only work with an 8bit palette that we construct of gray values.
             if (format == PixelFormat.Format8bppIndexed)
             {
                 var palette = bitmap.Palette;

--- a/src/Pfim.Viewer/MainWindow.xaml.cs
+++ b/src/Pfim.Viewer/MainWindow.xaml.cs
@@ -51,9 +51,7 @@ namespace Pfim.Viewer
 
         private static IImage ParseImage(string file)
         {
-            var result = Pfim.FromFile(file);
-            result.ApplyColorMap();
-            return result;
+            return Pfim.FromFile(file);
         }
 
         private static Image WpfImage(IImage image)

--- a/src/Pfim/PfimConfig.cs
+++ b/src/Pfim/PfimConfig.cs
@@ -6,13 +6,17 @@
             int bufferSize = 0x8000,
             TargetFormat targetFormat = TargetFormat.Native,
             bool decompress = true,
-            IImageAllocator allocator = null)
+            IImageAllocator allocator = null,
+            bool applyColorMap = true)
         {
             Allocator = allocator ?? new DefaultAllocator();
             BufferSize = bufferSize;
             TargetFormat = targetFormat;
             Decompress = decompress;
+            ApplyColorMap = applyColorMap;
         }
+
+        public bool ApplyColorMap { get; }
 
         public IImageAllocator Allocator { get; }
         public int BufferSize { get; }
@@ -29,14 +33,17 @@
 
         protected bool Equals(PfimConfig other)
         {
-            return Equals(Allocator, other.Allocator) && BufferSize == other.BufferSize && TargetFormat == other.TargetFormat && Decompress == other.Decompress;
+            return ApplyColorMap == other.ApplyColorMap && Allocator.Equals(other.Allocator) &&
+                   BufferSize == other.BufferSize && TargetFormat == other.TargetFormat &&
+                   Decompress == other.Decompress;
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = (Allocator != null ? Allocator.GetHashCode() : 0);
+                var hashCode = ApplyColorMap.GetHashCode();
+                hashCode = (hashCode * 397) ^ Allocator.GetHashCode();
                 hashCode = (hashCode * 397) ^ BufferSize;
                 hashCode = (hashCode * 397) ^ (int) TargetFormat;
                 hashCode = (hashCode * 397) ^ Decompress.GetHashCode();
@@ -46,7 +53,7 @@
 
         public override string ToString()
         {
-            return $"{nameof(Allocator)}: {Allocator}, {nameof(BufferSize)}: {BufferSize}, {nameof(TargetFormat)}: {TargetFormat}, {nameof(Decompress)}: {Decompress}";
+            return $"{nameof(ApplyColorMap)}: {ApplyColorMap}, {nameof(Allocator)}: {Allocator}, {nameof(BufferSize)}: {BufferSize}, {nameof(TargetFormat)}: {TargetFormat}, {nameof(Decompress)}: {Decompress}";
         }
     }
 }

--- a/src/Pfim/targa/Targa.cs
+++ b/src/Pfim/targa/Targa.cs
@@ -82,7 +82,14 @@ namespace Pfim
 
             var stride = Util.Stride(header.Width, header.PixelDepthBits);
             var len = header.Height * stride;
-            return new Targa(header, config, data, len);
+            var result = new Targa(header, config, data, len);
+
+            if (config.ApplyColorMap)
+            {
+                result.ApplyColorMap();
+            }
+
+            return result;
         }
 
         public void ApplyColorMap()

--- a/tests/Pfim.Tests/ImageTests.cs
+++ b/tests/Pfim.Tests/ImageTests.cs
@@ -69,9 +69,6 @@ namespace Pfim.Tests
 
             using (var image3 = Pfim.FromStream(new MemoryStream(data), new PfimConfig(allocator: allocator)))
             {
-                image.ApplyColorMap();
-                image2.ApplyColorMap();
-                image3.ApplyColorMap();
                 Assert.Equal(format, image.Format);
                 Assert.Equal(image.Format, image2.Format);
                 Assert.Equal(hash, Hash64(image.Data, image.DataLen));

--- a/tests/Pfim.Tests/TargaTests.cs
+++ b/tests/Pfim.Tests/TargaTests.cs
@@ -247,7 +247,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseTargaTopLeftColorMap()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"));
+            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
             Assert.Equal(8, image.BitsPerPixel);
             Assert.Equal(4096, image.Data.Length);
             Assert.NotEqual(ImageFormat.Rgb24, image.Format);
@@ -264,7 +264,7 @@ namespace Pfim.Tests
         [Fact]
         public void TargaColorMapIdempotent()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"));
+            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
             var firstData = image.Data;
             var firstLen = image.DataLen;
             image.ApplyColorMap();


### PR DESCRIPTION
Adds ApplyColorMap option to `PfimConfig` so that users can opt-out of
applying a (targa) colormap.

While this is a breaking change, targa images with color maps are rare
and the chance that someone was relying on them not being applied are
even rarer.

Closes #42