### PR TITLE
Fix decode issues on delayed decompression for dds

### DIFF
--- a/src/Pfim/dds/CompressedDds.cs
+++ b/src/Pfim/dds/CompressedDds.cs
@@ -168,12 +168,10 @@ namespace Pfim
                 var heightBlockAligned = HeightBlocks;
                 long totalSize = WidthBlocks * CompressedBytesPerBlock * heightBlockAligned;
 
-                var width = (int) Header.Width;
-                var height = (int) Header.Height;
                 for (int i = 1; i < Header.MipMapCount; i++)
                 {
-                    width = (int)Math.Pow(2, Math.Floor(Math.Log(width - 1, 2)));
-                    height = (int)Math.Pow(2, Math.Floor(Math.Log(height - 1, 2)));
+                    var width = (int)(Header.Width / Math.Pow(2, i));
+                    var height = (int)(Header.Height / Math.Pow(2, i));
                     var widthBlocks = Math.Max(DivSize, width) / DivSize;
                     var heightBlocks = Math.Max(DivSize, height) / DivSize;
                     totalSize += widthBlocks * heightBlocks * CompressedBytesPerBlock;

--- a/tests/Pfim.Tests/DdsTests.cs
+++ b/tests/Pfim.Tests/DdsTests.cs
@@ -172,6 +172,7 @@ namespace Pfim.Tests
         [InlineData("dxt5-simple-odd.dds")]
         [InlineData("dxt5-simple-1x1.dds")]
         [InlineData("Antenna_Metal_0_Normal.dds")]
+        [InlineData("wose_BC1_UNORM.DDS")]
         public void TestDdsCompression(string path)
         {
             var data = File.ReadAllBytes(Path.Combine("data", path));


### PR DESCRIPTION
When opting out of decoding block compressed dds files that contained mipmaps that didn't contain dimensions that were a power of two, an exception would be raised. The issue is fixed with proper calculation of mipmap dimensions.