### PR TITLE
Expose and decode mipmap data into image data

### DIFF
--- a/src/Pfim/IImage.cs
+++ b/src/Pfim/IImage.cs
@@ -36,8 +36,10 @@ namespace Pfim
 
         /// <summary>Decompress the image. Will have no effect if not compressed</summary>
         void Decompress();
-
+          
         ///<summary>Apply colormap, may change data and image format</summary>
         void ApplyColorMap();
+
+        MipMapOffset[] MipMaps { get; }
     }
 }

--- a/src/Pfim/MipMapOffset.cs
+++ b/src/Pfim/MipMapOffset.cs
@@ -1,0 +1,55 @@
+﻿namespace Pfim
+{
+    public class MipMapOffset
+    {
+        public MipMapOffset(int width, int height, int stride, int dataOffset, int dataLen)
+        {
+            Stride = stride;
+            Width = width;
+            Height = height;
+            DataOffset = dataOffset;
+            DataLen = dataLen;
+        }
+
+        public int Stride { get; }
+
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public int DataOffset { get; }
+
+        public int DataLen { get; }
+
+        protected bool Equals(MipMapOffset other)
+        {
+            return Stride == other.Stride && Width == other.Width && Height == other.Height && DataOffset == other.DataOffset && DataLen == other.DataLen;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Stride)}: {Stride}, {nameof(Width)}: {Width}, {nameof(Height)}: {Height}, {nameof(DataOffset)}: {DataOffset}, {nameof(DataLen)}: {DataLen}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((MipMapOffset) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Stride;
+                hashCode = (hashCode * 397) ^ Width;
+                hashCode = (hashCode * 397) ^ Height;
+                hashCode = (hashCode * 397) ^ DataOffset;
+                hashCode = (hashCode * 397) ^ DataLen;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/Pfim/Util.cs
+++ b/src/Pfim/Util.cs
@@ -81,27 +81,33 @@ namespace Pfim
             for (int i = 0; i < rem; i++)
                 buffer[length - i - 1] = value;
         }
-
-
-        public static void Fill(Stream stream, byte[] data, int dataLen, int bufSize = BUFFER_SIZE)
+        public static void Fill(Stream stream, byte[] data, int dataLen, int bufSize = BUFFER_SIZE, int offset = 0)
         {
             if (stream is MemoryStream s && s.TryGetBuffer(out var arr))
             {
-                Buffer.BlockCopy(arr.Array, (int)s.Position, data, 0, dataLen);
+                Buffer.BlockCopy(arr.Array, (int)s.Position, data, offset, dataLen);
+                s.Position += dataLen;
             }
             else
             {
-                InnerFill(stream, data, dataLen, bufSize);
+                InnerFill(stream, data, dataLen, bufSize, offset);
             }
         }
 
-        public static void InnerFillUnaligned(Stream str, byte[] buf, int bufLen, int width, int stride, int bufSize = BUFFER_SIZE)
+        public static void Fill(Stream stream, byte[] data, int dataLen, int bufSize = BUFFER_SIZE) => 
+            Fill(stream, data, dataLen, bufSize, 0);
+
+        public static void InnerFillUnaligned(Stream str, byte[] buf, int bufLen, int width, int stride, int bufSize = BUFFER_SIZE, int offset = 0)
         {
-            for (int i = 0; i < bufLen; i += stride)
+            for (int i = offset; i < bufLen + offset; i += stride)
             {
                 str.Read(buf, i, width);
             }
         }
+
+
+        public static void InnerFillUnaligned(Stream str, byte[] buf, int bufLen, int width, int stride, int bufSize = BUFFER_SIZE) =>
+            InnerFillUnaligned(str, buf, bufLen, width, stride, bufSize, 0);
 
         /// <summary>
         /// Fills the buffer all the way up with info from the stream
@@ -109,9 +115,9 @@ namespace Pfim
         /// <param name="str">Stream that will be used to fill the buffer</param>
         /// <param name="buf">Buffer that will house the information from the stream</param>
         /// <param name="bufSize">The chunk size of data that will be read from the stream</param>
-        private static void InnerFill(Stream str, byte[] buf, int dataLen, int bufSize = BUFFER_SIZE)
+        private static void InnerFill(Stream str, byte[] buf, int dataLen, int bufSize = BUFFER_SIZE, int offset = 0)
         {
-            int bufPosition = 0;
+            int bufPosition = offset;
             for (int i = dataLen / bufSize; i > 0; i--)
                 bufPosition += str.Read(buf, bufPosition, bufSize);
             str.Read(buf, bufPosition, dataLen % bufSize);

--- a/src/Pfim/dds/Dds.cs
+++ b/src/Pfim/dds/Dds.cs
@@ -104,6 +104,8 @@ namespace Pfim
         {
         }
 
+        public abstract MipMapOffset[] MipMaps { get; }
+
         public void Dispose()
         {
             _config.Allocator.Return(Data);

--- a/src/Pfim/targa/Targa.cs
+++ b/src/Pfim/targa/Targa.cs
@@ -135,6 +135,8 @@ namespace Pfim
             Header.ColorMapDepthBits = 0;
         }
 
+        public MipMapOffset[] MipMaps => new MipMapOffset[0];
+
         /// <summary>The raw image data</summary>
         public byte[] Data { get; private set; }
 

--- a/tests/Pfim.Tests/DdsTests.cs
+++ b/tests/Pfim.Tests/DdsTests.cs
@@ -186,5 +186,26 @@ namespace Pfim.Tests
             image2.Decompress();
             Assert.Equal(image.Data, image2.Data);
         }
+
+        [Fact]
+        public void TestDdsMipMap1()
+        {
+            var image = Pfim.FromFile(Path.Combine("data", "wose_BC1_UNORM.DDS"));
+            var expectedMips = new[]
+            {
+                new MipMapOffset(36, 36, 108, 15552, 3888),
+                new MipMapOffset(18, 18, 60, 19440, 1200),
+                new MipMapOffset(9, 9, 36, 20640, 432),
+                new MipMapOffset(4, 4, 12, 21072, 48),
+                new MipMapOffset(2, 2, 12, 21120, 48),
+                new MipMapOffset(1, 1, 12, 21168, 48)
+            };
+            Assert.Equal(expectedMips, image.MipMaps);
+            Assert.Equal(21168 + 48, image.Data.Length);
+
+            image = Dds.Create(File.ReadAllBytes(Path.Combine("data", "wose_BC1_UNORM.DDS")), new PfimConfig());
+            Assert.Equal(expectedMips, image.MipMaps);
+            Assert.Equal(21168 + 48, image.Data.Length);
+        }
     }
 }


### PR DESCRIPTION
Each image file may contain several images in addition to the main image decoded. There are pre-calculated / optimized for smaller dimensions -- often called [mipmaps](https://en.wikipedia.org/wiki/Mipmap). Previously there was no way to access these images until now.

New property under `IImage`

```
MipMapOffset[] MipMaps { get; }
```

With `MipMapOffset` defined with properties:

```csharp
public int Stride { get; }
public int Width { get; }
public int Height { get; }
public int DataOffset { get; }
public int DataLen { get; }
```

These should look familiar to known `IImage` properties, the one exception being `DataOffset`. This is the offset that the mipmap data starts in `IImage.Data`. To see usage, here is a snippet for WPF to split an `IImage` into separate images by mipmaps

```csharp
private IEnumerable<BitmapSource> WpfImage(IImage image)
{
    var pinnedArray = GCHandle.Alloc(image.Data, GCHandleType.Pinned);
    var addr = pinnedArray.AddrOfPinnedObject();
    var bsource = BitmapSource.Create(image.Width, image.Height, 96.0, 96.0, 
        PixelFormat(image), null, addr, image.DataLen, image.Stride);

    handles.Add(pinnedArray);
    yield return bsource;

    foreach (var mip in image.MipMaps)
    {
        var mipAddr = addr + mip.DataOffset;
        var mipSource = BitmapSource.Create(mip.Width, mip.Height, 96.0, 96.0,
            PixelFormat(image), null, mipAddr, mip.DataLen, mip.Stride);
        yield return mipSource;
    }
}
```

Example image:

![image](https://user-images.githubusercontent.com/2106129/63165974-a0aa0a80-bff2-11e9-9074-a7463fb286c5.png)

Only additional images are stored in `MipMaps` (the base image is excluded).

This continues the work in `0.7.0` were users should start relying on the `DataLen` property and not `Data.Length` as now multiple images share this buffer

Closes  #45

cc @adamkvd