### PR TITLE
Bump project target framework to 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
     - run: dotnet build src/Pfim/Pfim.csproj
     - run: dotnet build src/Pfim.ImageSharp/Pfim.ImageSharp.csproj
     - run: dotnet build src/Pfim.Skia/Pfim.Skia.csproj

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cd src\Pfim.Benchmarks\bin\Release\net461
 Building the library is as easy as
 
 ```
-dotnet test -f netcoreapp3.1
+dotnet test -f net6.0
 ```
 
 Or hit "Build" in Visual Studio :smile:

--- a/src/Pfim.ImageSharp/Pfim.ImageSharp.csproj
+++ b/src/Pfim.ImageSharp/Pfim.ImageSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pfim.MonoGame/Pfim.MonoGame.csproj
+++ b/src/Pfim.MonoGame/Pfim.MonoGame.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pfim.Skia/Pfim.Skia.csproj
+++ b/src/Pfim.Skia/Pfim.Skia.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Pfim.Tests/Pfim.Tests.csproj
+++ b/tests/Pfim.Tests/Pfim.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Farmhash.Sharp" Version="0.7.0" />


### PR DESCRIPTION
With support for .NET Core 3.1 (LTS) coming to a close at the end of
this year, this commit updates projects and CI from 3.1 to 6.0.