### PR TITLE
Update benchmark to net 6 with dependency fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,10 @@ jobs:
     - run: dotnet build src/Pfim.Benchmarks/Pfim.Benchmarks.csproj
     - run: dotnet build src/Pfim.Viewer.Forms/Pfim.Viewer.Forms.csproj
     - run: dotnet build src/Pfim.Viewer/Pfim.Viewer.csproj
+    - run: |
+        dotnet run -c Release --project ./src/Pfim.Benchmarks -- --filter * --job Dry
+        $SEL = Select-String -Path ./BenchmarkDotNet.Artifacts/*.log -Pattern "Benchmarks with issues"
+        if ($SEL -ne $null)
+        {
+          exit 1
+        }

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Pfim is fast. Faster than anything benchmarked in C#.
 
 The contestants:
 
-- Pfim 0.7.0
-- [DevIL](http://openil.sourceforge.net/) 0.2.4
+- Pfim 0.10.0
+- [DevIL](http://openil.sourceforge.net/) 0.2.19
 - [FreeImage](http://freeimage.sourceforge.net/) 4.3.6
 - [ImageMagick](https://www.imagemagick.org/script/index.php) 7.12.0
 - [TargaImage](https://www.codeproject.com/Articles/31702/NET-Targa-Image-Reader) 1.0
@@ -159,11 +159,9 @@ All contributions are welcome. Here is a quick guideline:
 - Have a performance improvement for Pfim? Excellent, run the before and after benchmarks!
 
 ```
-dotnet build -c Release -f net461  .\src\Pfim.Benchmarks\Pfim.Benchmarks.csproj
-cd src\Pfim.Benchmarks\bin\Release\net461
-.\Pfim.Benchmarks.exe --filter *.Pfim
+dotnet run -c Release --project .\src\Pfim.Benchmarks -- --filter '*.Pfim'
 ```
-- Know a library to include in the benchmarks? If it is NuGet installable / easily integratable, please raise an issue or pull request! It must run on .NET 4.6.
+- Know a library to include in the benchmarks? If it is NuGet installable / easily integratable, please raise an issue or pull request!
 
 ## Developer Resources
 

--- a/src/Pfim.Benchmarks/DdsBenchmark.cs
+++ b/src/Pfim.Benchmarks/DdsBenchmark.cs
@@ -21,6 +21,8 @@ namespace Pfim.Benchmarks
         public void SetupData()
         {
             data = File.ReadAllBytes(Path.Combine("bench", Payload));
+
+            Aardvark.Base.Aardvark.Init();
             DS.Bootstrap.Init();
         }
 

--- a/src/Pfim.Benchmarks/Pfim.Benchmarks.csproj
+++ b/src/Pfim.Benchmarks/Pfim.Benchmarks.csproj
@@ -2,20 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aardvark.Base" Version="5.2.10" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="DevILSharp" Version="0.2.4" />
-    <PackageReference Include="FreeImage-dotnet-core" Version="4.3.6" />
-    <PackageReference Include="FSharp.Core" Version="4.3.1" />
+    <PackageReference Include="DevILSharp" Version="0.2.19" />
+    <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
     <PackageReference Include="ImageFormats" Version="1.0.0" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.12.0" />
     <PackageReference Include="StbSharp" Version="0.7.2.38" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,5 +27,4 @@
     <Compile Include="..\..\lib\TGASharpLib.cs" Link="TGASharpLib.cs" />
     <Compile Include="..\..\tests\Pfim.Tests\PfimAllocator.cs" Link="PfimAllocator.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/Pfim.Benchmarks/TargaBenchmark.cs
+++ b/src/Pfim.Benchmarks/TargaBenchmark.cs
@@ -24,9 +24,9 @@ namespace Pfim.Benchmarks
         [GlobalSetup]
         public void SetupData()
         {
-            var loc = System.Reflection.Assembly.GetEntryAssembly().Location;
-            var dir = Path.GetDirectoryName(loc);
-            data = File.ReadAllBytes(Path.Combine(dir, "bench", Payload));
+            data = File.ReadAllBytes(Path.Combine("bench", Payload));
+
+            Aardvark.Base.Aardvark.Init();
             DS.Bootstrap.Init();
         }
 


### PR DESCRIPTION
- Now all (non-library) projects within pfim target net6
- DevILSharp wasn't working without aardvark initialization
- Freeimage dependency was changed to a forked project that targets .net
standard
- Adding benchmark testing to CI. Doesn't look like benchmarkdotnet has
an option to exit with non-zero status code on test exception, so we
have to roll our own error detection.