### PR TITLE
Rename Pfim class to Pfimage to avoid NS collision

### DIFF
--- a/src/Pfim.ImageSharp/Program.cs
+++ b/src/Pfim.ImageSharp/Program.cs
@@ -19,7 +19,7 @@ namespace Pfim.ImageSharp
 
         private static void ConvertFile(string file)
         {
-            using (var image = Pfim.FromFile(file))
+            using (var image = Pfimage.FromFile(file))
             {
                 byte[] newData;
 

--- a/src/Pfim.MonoGame/MyGame.cs
+++ b/src/Pfim.MonoGame/MyGame.cs
@@ -68,7 +68,7 @@ namespace Pfim.MonoGame
 
         private Texture2D CreateTexture(string file)
         {
-            var image = Pfim.FromFile(file);
+            var image = Pfimage.FromFile(file);
             byte[] newData;
 
             // Since mono game can't handle data with line padding in a stride

--- a/src/Pfim.Skia/Program.cs
+++ b/src/Pfim.Skia/Program.cs
@@ -18,7 +18,7 @@ namespace Pfim.Skia
         private static void ConvertFile(string file)
         {
             SKColorType colorType;
-            using (var image = Pfim.FromFile(file))
+            using (var image = Pfimage.FromFile(file))
             {
                 var newData = image.Data;
                 var newDataLen = image.DataLen;

--- a/src/Pfim.Viewer.Forms/Form1.cs
+++ b/src/Pfim.Viewer.Forms/Form1.cs
@@ -29,7 +29,7 @@ namespace Pfim.Viewer.Forms
                 return;
             }
 
-            var image = Pfim.FromFile(dialog.FileName);
+            var image = Pfimage.FromFile(dialog.FileName);
 
             PixelFormat format;
             switch (image.Format)

--- a/src/Pfim.Viewer/MainWindow.xaml.cs
+++ b/src/Pfim.Viewer/MainWindow.xaml.cs
@@ -53,7 +53,7 @@ namespace Pfim.Viewer
 
             foreach (var file in images)
             {
-                IImage image = await Task.Run(() => Pfim.FromFile(file));
+                IImage image = await Task.Run(() => Pfimage.FromFile(file));
                 foreach (var im in WpfImage(image))
                 {
                     ImagePanel.Children.Add(im);

--- a/src/Pfim/Pfimage.cs
+++ b/src/Pfim/Pfimage.cs
@@ -4,7 +4,7 @@ using System.IO;
 namespace Pfim
 {
     /// <summary>Decodes images into a uniform structure</summary>
-    public static class Pfim
+    public static class Pfimage
     {
         public static IImage FromFile(string path)
         {

--- a/tests/Pfim.Tests/DdsTests.cs
+++ b/tests/Pfim.Tests/DdsTests.cs
@@ -9,7 +9,7 @@ namespace Pfim.Tests
         [Fact]
         public void Parse32BitUncompressedDds()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "32-bit-uncompressed.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "32-bit-uncompressed.dds"));
             byte[] data = new byte[64 * 64 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -27,7 +27,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleDxt1()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt1-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt1-simple.dds"));
             byte[] data = new byte[64 * 64 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -45,7 +45,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseDxt1Alpha()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt1-alpha.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt1-alpha.dds"));
             Assert.Equal(0, image.Data[34]); // check alpha is off
             Assert.Equal(64, image.Height);
             Assert.Equal(128, image.Width);
@@ -68,7 +68,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleDxt3()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt3-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt3-simple.dds"));
             byte[] data = new byte[64 * 64 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -86,7 +86,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleDxt5()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt5-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt5-simple.dds"));
             byte[] data = new byte[64 * 64 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -104,7 +104,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleDxt5Odd()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt5-simple-odd.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt5-simple-odd.dds"));
             Assert.Equal(32, image.Stride);
             Assert.Equal(0, image.Data[8 * 5 * 4]);
             Assert.Equal(0, image.Data[8 * 5 * 4 + 1]);
@@ -129,7 +129,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc2()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc2-simple-srgb.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc2-simple-srgb.dds"));
             Assert.True(image is Dxt3Dds);
             Assert.Equal(DxgiFormat.BC2_UNORM_SRGB, ((Dxt3Dds)image).Header10?.DxgiFormat);
 
@@ -150,7 +150,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc3()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc3-simple-srgb.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc3-simple-srgb.dds"));
             Assert.True(image is Dxt5Dds);
             Assert.Equal(DxgiFormat.BC3_UNORM_SRGB, ((Dxt5Dds)image).Header10?.DxgiFormat);
 
@@ -171,7 +171,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc4()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc4-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc4-simple.dds"));
             Assert.True(image is Bc4Dds);
             Assert.Equal(CompressionAlgorithm.BC4U, ((Bc4Dds)image).Header?.PixelFormat.FourCC);
 
@@ -189,7 +189,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc5()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc5-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc5-simple.dds"));
             Assert.True(image is Bc5Dds);
             Assert.Equal(CompressionAlgorithm.BC5U, ((Bc5Dds)image).Header?.PixelFormat.FourCC);
 
@@ -209,7 +209,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc5s()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc5-simple-snorm.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc5-simple-snorm.dds"));
             Assert.True(image is Bc5sDds);
             Assert.Equal(CompressionAlgorithm.BC5S, ((Bc5sDds)image).Header?.PixelFormat.FourCC);
 
@@ -229,7 +229,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc6h()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc6h-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc6h-simple.dds"));
             Assert.True(image is Bc6hDds);
             Assert.Equal(DxgiFormat.BC6H_UF16, ((Bc6hDds)image).Header10?.DxgiFormat);
 
@@ -250,7 +250,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleBc7()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "bc7-simple.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "bc7-simple.dds"));
             byte[] data = new byte[64 * 64 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -272,7 +272,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleUncompressedOdd()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "32-bit-uncompressed-odd.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "32-bit-uncompressed-odd.dds"));
             Assert.Equal(20, image.Stride);
             Assert.Equal(5 * 9 * 4, image.Data.Length);
             Assert.Equal(9, image.Height);
@@ -293,7 +293,7 @@ namespace Pfim.Tests
         [Fact]
         public void Parse24bitUncompressedOdd()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "24-bit-uncompressed-odd.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "24-bit-uncompressed-odd.dds"));
             Assert.Equal(4, image.Stride);
             Assert.Equal(12, image.Data.Length);
             Assert.Equal(3, image.Height);
@@ -313,7 +313,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseSimpleDxt51x1()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "dxt5-simple-1x1.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "dxt5-simple-1x1.dds"));
             Assert.Equal(16, image.Stride);
             Assert.Equal(0, image.Data[0]);
             Assert.Equal(0, image.Data[1]);
@@ -327,7 +327,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseWoseBc1Snorm()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "wose_BC1_UNORM_SRGB.DDS"));
+            var image = Pfimage.FromFile(Path.Combine("data", "wose_BC1_UNORM_SRGB.DDS"));
             Assert.IsAssignableFrom<Dds>(image);
             var dds = (Dds)image;
             Assert.Equal(DxgiFormat.BC1_UNORM_SRGB, dds.Header10?.DxgiFormat);
@@ -358,7 +358,7 @@ namespace Pfim.Tests
         [Fact]
         public void TestDdsMipMap1()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "wose_BC1_UNORM.DDS"));
+            var image = Pfimage.FromFile(Path.Combine("data", "wose_BC1_UNORM.DDS"));
             var expectedMips = new[]
             {
                 new MipMapOffset(36, 36, 144, 20736, 5184),
@@ -379,7 +379,7 @@ namespace Pfim.Tests
         [Fact]
         public void TestBc1UnormSrgb47Dds()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "BC1_UNORM_SRGB-47.dds"));
+            var image = Pfimage.FromFile(Path.Combine("data", "BC1_UNORM_SRGB-47.dds"));
             byte[] data = new byte[349632];
             for (int i = 0; i < data.Length; i += 4)
             {

--- a/tests/Pfim.Tests/ImageTests.cs
+++ b/tests/Pfim.Tests/ImageTests.cs
@@ -73,15 +73,15 @@ namespace Pfim.Tests
         {
             var path = Path.Combine("data", Path.Combine(allPath.Split('\\')));
             var data = File.ReadAllBytes(path);
-            var image = Pfim.FromFile(path);
-            var image2 = Pfim.FromStream(new MemoryStream(data), new PfimConfig());
+            var image = Pfimage.FromFile(path);
+            var image2 = Pfimage.FromStream(new MemoryStream(data), new PfimConfig());
             Assert.NotEqual(0, image.DataLen);
             Assert.NotEqual(0, image2.DataLen);
 
             var allocator = new PfimAllocator();
             Assert.Equal(0, allocator.Rented);
 
-            using (var image3 = Pfim.FromStream(new ChunkedStream(data), new PfimConfig(allocator: allocator, bufferSize: 600)))
+            using (var image3 = Pfimage.FromStream(new ChunkedStream(data), new PfimConfig(allocator: allocator, bufferSize: 600)))
             {
                 Assert.Equal(format, image.Format);
                 Assert.Equal(image.Format, image2.Format);
@@ -109,7 +109,7 @@ namespace Pfim.Tests
         {
             var path = Path.Combine("data", Path.Combine(allPath.Split('\\')));
             var data = File.ReadAllBytes(path);
-            var image = Pfim.FromFile(path);
+            var image = Pfimage.FromFile(path);
             var image2 = Dds.Create(data, new PfimConfig());
             Assert.Equal(image.MipMaps, image2.MipMaps);
             Assert.Equal(Hash64(image.Data, image.DataLen), Hash64(image2.Data, image2.DataLen));

--- a/tests/Pfim.Tests/TargaTests.cs
+++ b/tests/Pfim.Tests/TargaTests.cs
@@ -18,7 +18,7 @@ namespace Pfim.Tests
                 expected[i + 2] = 0;
             }
 
-            var image = Pfim.FromFile(Path.Combine("data", "true-24.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-24.tga"));
             Assert.Equal(expected, image.Data);
         }
 
@@ -34,7 +34,7 @@ namespace Pfim.Tests
                 expected[i + 3] = 255;
             }
 
-            var image = Pfim.FromFile(Path.Combine("data", "true-32.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-32.tga"));
             Assert.Equal(expected, image.Data);
         }
 
@@ -99,7 +99,7 @@ namespace Pfim.Tests
                 data[i + 3] = 255;
             }
 
-            var image = Pfim.FromFile(Path.Combine("data", "true-32-rle.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-32-rle.tga"));
 
             Assert.Equal(data, image.Data);
         }
@@ -134,7 +134,7 @@ namespace Pfim.Tests
                 data[i + 2] = 255;
             }
 
-            var image = Pfim.FromFile(Path.Combine("data", "true-24-rle.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-24-rle.tga"));
 
             Assert.Equal(data, image.Data);
         }
@@ -142,7 +142,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseUncompressedNonSquareTga()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "tiny-rect.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "tiny-rect.tga"));
             byte[] data = new byte[12 * 20 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -157,7 +157,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseTrueTarga32MixedEncoding()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "true-32-mixed.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-32-mixed.tga"));
             byte[] data = new byte[256];
             for (int i = 0; i < 16 * 4; i += 4)
             {
@@ -209,7 +209,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseLarge32TargetImage()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "true-32-rle-large.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "true-32-rle-large.tga"));
             byte[] data = new byte[1200 * 1200 * 4];
             for (int i = 0; i < data.Length; i += 4)
             {
@@ -225,7 +225,7 @@ namespace Pfim.Tests
         public void ParseTargaTopLeft()
         {
             bool seenBlue = false;
-            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "rgb24_top_left.tga"));
             for (int i = 0; i < image.Data.Length; i += 3)
             {
                 seenBlue |= image.Data[i] == 12 && image.Data[i + 1] == 0 && image.Data[i + 2] == 255;
@@ -247,7 +247,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseTargaTopLeftColorMap()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
+            var image = Pfimage.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
             Assert.Equal(8, image.BitsPerPixel);
             Assert.Equal(4096, image.Data.Length);
             Assert.NotEqual(ImageFormat.Rgb24, image.Format);
@@ -264,7 +264,7 @@ namespace Pfim.Tests
         [Fact]
         public void TargaColorMapIdempotent()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
+            var image = Pfimage.FromFile(Path.Combine("data", "rgb24_top_left_colormap.tga"), new PfimConfig(applyColorMap: false));
             var firstData = image.Data;
             var firstLen = image.DataLen;
             image.ApplyColorMap();
@@ -299,7 +299,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseLargeTargaTopLeft()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "large-top-left.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "large-top-left.tga"));
             foreach (byte bt in image.Data)
             {
                 Assert.Equal(0, bt);
@@ -309,7 +309,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseLargeTargaBottomLeft()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "marbles.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "marbles.tga"));
             Assert.Equal(4264260, image.Data.Length);
             Assert.Equal(0, image.Data[0]);
             Assert.Equal(0, image.Data[1]);
@@ -319,7 +319,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseMarblesTarga()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "marbles2.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "marbles2.tga"));
             Assert.Equal(100 * 71 * 3, image.Data.Length);
             Assert.Equal(2, image.Data[0]);
             Assert.Equal(3, image.Data[1]);
@@ -329,7 +329,7 @@ namespace Pfim.Tests
         [Fact]
         public void ParseTransparentTarga()
         {
-            var image = Pfim.FromFile(Path.Combine("data", "flag_t32.tga"));
+            var image = Pfimage.FromFile(Path.Combine("data", "flag_t32.tga"));
             for (int i = 0; i < image.Data.Length; i += 4)
             {
                 Assert.Equal(0, image.Data[i + 3]);
@@ -340,7 +340,7 @@ namespace Pfim.Tests
         public void InvalidTargaException()
         {
             var data = Encoding.ASCII.GetBytes("Hello world! A wonderful evening");
-            var ex = Assert.ThrowsAny<Exception>(() => Pfim.FromStream(new MemoryStream(data)));
+            var ex = Assert.ThrowsAny<Exception>(() => Pfimage.FromStream(new MemoryStream(data)));
             Assert.Equal("Detected invalid targa image", ex.Message);
         }
     }


### PR DESCRIPTION
Closes #94 

Not 100% sure on the name, so I'll let it sink in.