### PR TITLE
Allow image decoding on smaller buffers and chunked streams

### DIFF
--- a/src/Pfim/Pfim.cs
+++ b/src/Pfim/Pfim.cs
@@ -37,11 +37,7 @@ namespace Pfim
         public static IImage FromStream(Stream stream, PfimConfig config)
         {
             byte[] magic = new byte[4];
-            if (stream.Read(magic, 0, 4) != 4)
-            {
-                throw new ArgumentException("stream must contain magic header", nameof(stream));
-            }
-
+            Util.ReadExactly(stream, magic, 0, magic.Length);
             if (magic[0] == 0x44 && magic[1] == 0x44 && magic[2] == 0x53 && magic[3] == 0x20)
             {
                 return Dds.CreateSkipMagic(stream, config);

--- a/src/Pfim/dds/DdsHeader.cs
+++ b/src/Pfim/dds/DdsHeader.cs
@@ -225,11 +225,7 @@ namespace Pfim
             var headerSize = skipMagic ? SIZE : SIZE + 4;
             byte[] buffer = new byte[headerSize];
             Reserved1 = new uint[11];
-            int bufferSize = stream.Read(buffer, 0, headerSize);
-            if (bufferSize != headerSize)
-            {
-                throw new Exception($"Need at least {SIZE + 4} bytes for a valid DDS header");
-            }
+            Util.ReadExactly(stream, buffer, 0, headerSize);
 
             fixed (byte* bufferPtr = buffer)
             {

--- a/src/Pfim/dds/DdsHeaderDxt10.cs
+++ b/src/Pfim/dds/DdsHeaderDxt10.cs
@@ -17,10 +17,7 @@ namespace Pfim
         public unsafe DdsHeaderDxt10(Stream stream)
         {
             byte[] buffer = new byte[5 * 4];
-            if (stream.Read(buffer, 0, buffer.Length) != buffer.Length)
-            {
-                throw new Exception($"Need at least {buffer.Length} bytes for a valid DDS DX10 header");
-            }
+            Util.ReadExactly(stream, buffer, 0, buffer.Length);
 
             fixed (byte* bufferPtr = buffer)
             {

--- a/src/Pfim/targa/CompressedTarga.cs
+++ b/src/Pfim/targa/CompressedTarga.cs
@@ -95,11 +95,15 @@ namespace Pfim
             // If our buffer doesn't have enough to decode the maximum number of bytes,
             // fetch another batch of bytes from the stream.
             int maxRead = bytesPerPixel * 128 + 1;
+            if (config.BufferSize < maxRead)
+            {
+                throw new ArgumentException($"Buffer size not big enough to read {maxRead} bytes", nameof(config.BufferSize));
+            }
 
             byte[] filebuffer = config.Allocator.Rent(config.BufferSize);
             try
             {
-                int workingSize = str.Read(filebuffer, 0, config.BufferSize);
+                int workingSize = Util.ReadFill(str, filebuffer, 0, config.BufferSize);
                 while (dataIndex >= 0)
                 {
                     int colIndex = 0;
@@ -167,9 +171,13 @@ namespace Pfim
             // If our buffer doesn't have enough to decode the maximum number of bytes,
             // fetch another batch of bytes from the stream.
             int maxRead = bytesPerPixel * 128 + 1;
+            if (config.BufferSize < maxRead)
+            {
+                throw new ArgumentException($"Buffer size not big enough to read {maxRead} bytes", nameof(config.BufferSize));
+            }
 
             byte[] filebuffer = config.Allocator.Rent(config.BufferSize);
-            int workingSize = str.Read(filebuffer, 0, config.BufferSize);
+            int workingSize = Util.ReadFill(str, filebuffer, 0, config.BufferSize);
 
             try
             {

--- a/src/Pfim/targa/TargaHeader.cs
+++ b/src/Pfim/targa/TargaHeader.cs
@@ -73,11 +73,7 @@ namespace Pfim
         public TargaHeader(Stream str, PfimConfig config)
         {
             byte[] buf = new byte[MINIMUM_SIZE];
-            if (str.Read(buf, 0, MINIMUM_SIZE) != MINIMUM_SIZE)
-            {
-                throw new ArgumentException("Stream doesn't have enough data for a .tga", nameof(str));
-            }
-
+            Util.ReadExactly(str, buf, 0, buf.Length);
             DecodeTargaHeader(str, buf, MINIMUM_SIZE, config);
         }
 
@@ -102,10 +98,7 @@ namespace Pfim
                     buf[i] = partial[i];
                 }
 
-                if (str.Read(buf, partialLen, left) != left)
-                {
-                    throw new ArgumentException("Stream doesn't have enough data for a .tga", nameof(str));
-                }
+                Util.ReadExactly(str, buf, partialLen, left);
             }
 
             IDLength = buf[0];
@@ -131,8 +124,8 @@ namespace Pfim
             if (IDLength != 0)
             {
                 var idBuf = new byte[IDLength];
-                var amount = str.Read(idBuf, 0, IDLength);
-                ImageId = Encoding.Unicode.GetString(idBuf, 0, amount);
+                Util.ReadExactly(str, idBuf, 0, IDLength);
+                ImageId = Encoding.Unicode.GetString(idBuf, 0, IDLength);
             }
 
             if (HasColorMap)
@@ -144,7 +137,7 @@ namespace Pfim
 
                 var mapBytes = ColorMapDepthBytes;
                 ColorMap = new byte[ColorMapLength * mapBytes];
-                str.Read(ColorMap, ColorMapOrigin * mapBytes, (ColorMapLength - ColorMapOrigin) * mapBytes);
+                Util.ReadExactly(str, ColorMap, ColorMapOrigin * mapBytes, (ColorMapLength - ColorMapOrigin) * mapBytes);
             }
         }
 

--- a/tests/Pfim.Tests/ChunkedStream.cs
+++ b/tests/Pfim.Tests/ChunkedStream.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+
+namespace Pfim.Tests
+{
+    public class ChunkedStream : Stream
+    {
+        private readonly byte[] data;
+        public ChunkedStream(byte[] data) => this.data = data;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => data.Length;
+
+        public override long Position { get; set; }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int toCopy = Math.Min(Math.Min(count, 100), (int)(data.Length - Position));
+            Buffer.BlockCopy(data, (int)Position, buffer, offset, toCopy);
+            Position += toCopy;
+            return toCopy;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Pfim.Tests/ImageTests.cs
+++ b/tests/Pfim.Tests/ImageTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using Xunit;
 using static Farmhash.Sharp.Farmhash;
@@ -80,7 +81,7 @@ namespace Pfim.Tests
             var allocator = new PfimAllocator();
             Assert.Equal(0, allocator.Rented);
 
-            using (var image3 = Pfim.FromStream(new MemoryStream(data), new PfimConfig(allocator: allocator)))
+            using (var image3 = Pfim.FromStream(new ChunkedStream(data), new PfimConfig(allocator: allocator, bufferSize: 600)))
             {
                 Assert.Equal(format, image.Format);
                 Assert.Equal(image.Format, image2.Format);
@@ -111,6 +112,11 @@ namespace Pfim.Tests
             var image = Pfim.FromFile(path);
             var image2 = Dds.Create(data, new PfimConfig());
             Assert.Equal(image.MipMaps, image2.MipMaps);
+            Assert.Equal(Hash64(image.Data, image.DataLen), Hash64(image2.Data, image2.DataLen));
+
+            var maps = image.MipMaps.Select((x) => Hash64(new Span<byte>(image.Data, x.DataOffset, x.DataLen))).ToList();
+            var maps2 = image2.MipMaps.Select((x) => Hash64(new Span<byte>(image2.Data, x.DataOffset, x.DataLen))).ToList();
+            Assert.Equal(maps, maps2);
 
             var mipMapLengths = image.MipMaps.Sum(x => x.DataLen);
             var hash1 = Hash64(image.Data, image.DataLen + mipMapLengths);


### PR DESCRIPTION
Currently pfim will fail to decode a dds image if there is not enough
data available to decode an entire row of the image. The default buffer
size will be insufficient on large images (like an image with a width of
16384 pixels). This PR fixes the problem by only requiring the buffer to
be big enough to decode a block of pixels instead an entire row.

Pfim will also fail to properly incorporate chunked streams into the
decode process. A chunked stream is one where a `Read` will yield data
but won't fill the buffer in its entirety (and the stream is not
finished). [This is documented behavior][0].

> An implementation is free to return fewer bytes than requested even if
> the end of the stream has not been reached.

The fix is to convert all stream reads so that they fill the buffer provided.

[0]: https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.read?view=net-6.0#definition

Closes #86