### PR TITLE
Convert out methods of color float

### DIFF
--- a/src/Pfim/dds/Colors.cs
+++ b/src/Pfim/dds/Colors.cs
@@ -1,6 +1,6 @@
 ﻿namespace Pfim
 {
-    struct Colors888
+    struct Color888
     {
         public byte r;
         public byte g;
@@ -34,28 +34,26 @@
             };
         }
 
-        public ColorFloatRgb Lerp(ColorFloatRgb other, float blend)
+        public ColorFloatRgb Lerp(ColorFloatRgb other, float blend) => new ColorFloatRgb()
         {
-            return new ColorFloatRgb()
-            {
-                r = r + blend * (other.r - r),
-                g = g + blend * (other.g - g),
-                b = b + blend * (other.b - b),
-            };
-        }
+            r = r + blend * (other.r - r),
+            g = g + blend * (other.g - g),
+            b = b + blend * (other.b - b),
+        };
 
-        public void As8Bit(out Colors888 result)
+        public Color888 As8Bit() => new Color888
         {
-            result.r = (byte)(r + 0.5f);
-            result.g = (byte)(g + 0.5f);
-            result.b = (byte)(b + 0.5f);
-        }
-        public void As8Bit(out Color8888 result)
+            r = (byte)(r + 0.5f),
+            g = (byte)(g + 0.5f),
+            b = (byte)(b + 0.5f),
+        };
+
+        public Color8888 As8BitA() => new Color8888
         {
-            result.r = (byte)(r + 0.5f);
-            result.g = (byte)(g + 0.5f);
-            result.b = (byte)(b + 0.5f);
-            result.a = 255;
-        }
+            r = (byte)(r + 0.5f),
+            g = (byte)(g + 0.5f),
+            b = (byte)(b + 0.5f),
+            a = 255,
+        };
     }
 }

--- a/src/Pfim/dds/Dxt3Dds.cs
+++ b/src/Pfim/dds/Dxt3Dds.cs
@@ -15,8 +15,6 @@
         {
         }
 
-        private readonly Colors888[] colors = new Colors888[4];
-
         protected override int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
         {
             /*
@@ -43,10 +41,8 @@
             var c0 = ColorFloatRgb.FromRgb565(color0);
             var c1 = ColorFloatRgb.FromRgb565(color1);
 
-            c0.As8Bit(out colors[0]);
-            c1.As8Bit(out colors[1]);
-            c0.Lerp(c1, 0.33333333f).As8Bit(out colors[2]);
-            c0.Lerp(c1, 0.66666666f).As8Bit(out colors[3]);
+            (var i0, var i1) = (c0.As8Bit(), c1.As8Bit());
+            Color888[] colors = new[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
 
             for (int i = 0; i < 4; i++)
             {

--- a/src/Pfim/dds/Dxt5Dds.cs
+++ b/src/Pfim/dds/Dxt5Dds.cs
@@ -8,7 +8,6 @@ namespace Pfim
         private const byte DIV_SIZE = 4;
 
         private readonly byte[] alpha = new byte[8];
-        private readonly Colors888[] colors = new Colors888[4];
 
         public override int BitsPerPixel => 8 * PIXEL_DEPTH;
         public override ImageFormat Format => ImageFormat.Rgba32;
@@ -43,10 +42,8 @@ namespace Pfim
             var c0 = ColorFloatRgb.FromRgb565(color0);
             var c1 = ColorFloatRgb.FromRgb565(color1);
 
-            c0.As8Bit(out colors[0]);
-            c1.As8Bit(out colors[1]);
-            c0.Lerp(c1, 0.33333333f).As8Bit(out colors[2]);
-            c0.Lerp(c1, 0.66666666f).As8Bit(out colors[3]);
+            (var i0, var i1) = (c0.As8Bit(), c1.As8Bit());
+            Color888[] colors = new[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
 
             for (int alphaShift = 0; alphaShift < 48; alphaShift += 12)
             {


### PR DESCRIPTION
Benchmarks showed no difference when the color array was inlined into
the method body and `ColorFloatRgb` returned new values instead of
modifying the parameter.