### PR TITLE
Reduce allocations during image decoding.

### DIFF
--- a/src/Pfim/dds/Bc5Dds.cs
+++ b/src/Pfim/dds/Bc5Dds.cs
@@ -2,9 +2,6 @@
 {
     public class Bc5Dds : CompressedDds
     {
-        private readonly byte[] _firstGradient = new byte[8];
-        private readonly byte[] _secondGradient = new byte[8];
-
         public Bc5Dds(DdsHeader header, PfimConfig config) : base(header, config)
         {
         }
@@ -15,8 +12,11 @@
         protected override byte DivSize => 4;
         protected override byte CompressedBytesPerBlock => 16;
 
-        protected override int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
+        protected override unsafe int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
         {
+            byte* _firstGradient = stackalloc byte[8];
+            byte* _secondGradient = stackalloc byte[8];
+
             streamIndex = ExtractGradient(_firstGradient, stream, streamIndex);
             ulong firstCodes = stream[streamIndex++];
             firstCodes |= ((ulong)stream[streamIndex++] << 8);
@@ -50,7 +50,7 @@
             return streamIndex;
         }
 
-        internal static int ExtractGradient(byte[] gradient, byte[] stream, int bIndex)
+        internal static unsafe int ExtractGradient(byte* gradient, byte[] stream, int bIndex)
         {
             byte endpoint0;
             byte endpoint1;

--- a/src/Pfim/dds/Bc6hBc7/INTColor.cs
+++ b/src/Pfim/dds/Bc6hBc7/INTColor.cs
@@ -63,11 +63,11 @@ namespace Pfim.dds.Bc6hBc7
             return ((((x) & (1 << ((nb) - 1))) != 0 ? ((~0) ^ ((1 << (nb)) - 1)) : 0) | (x));
         }
 
-        public void ToF16(ushort[] aF16, bool bSigned)
+        public void ToF16(out ushort red, out ushort green, out ushort blue, bool bSigned)
         {
-            aF16[0] = INT2F16(r, bSigned);
-            aF16[1] = INT2F16(g, bSigned);
-            aF16[2] = INT2F16(b, bSigned);
+            red = INT2F16(r, bSigned);
+            green = INT2F16(g, bSigned);
+            blue = INT2F16(b, bSigned);
         }
 
         private static ushort INT2F16(int input, bool bSigned)

--- a/src/Pfim/dds/Bc6hDds.cs
+++ b/src/Pfim/dds/Bc6hDds.cs
@@ -421,13 +421,12 @@ namespace Pfim.dds
                     fc.g = FinishUnquantize((g1 * (Constants.BC67_WEIGHT_MAX - aWeights[uIndex]) + g2 * aWeights[uIndex] + Constants.BC67_WEIGHT_ROUND) >> Constants.BC67_WEIGHT_SHIFT, bSigned);
                     fc.b = FinishUnquantize((b1 * (Constants.BC67_WEIGHT_MAX - aWeights[uIndex]) + b2 * aWeights[uIndex] + Constants.BC67_WEIGHT_ROUND) >> Constants.BC67_WEIGHT_SHIFT, bSigned);
 
-                    ushort[] rgb = new ushort[3];
-                    fc.ToF16(rgb, bSigned);
+                    fc.ToF16(out ushort r, out ushort g, out ushort b, bSigned);
 
                     // Clamp 0..1, and convert to byte (we're losing high dynamic range)
-                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(rgb[2]))) * 255.0f) + 0.5f); // blue
-                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(rgb[1]))) * 255.0f) + 0.5f); // green
-                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(rgb[0]))) * 255.0f) + 0.5f); // red
+                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(b))) * 255.0f) + 0.5f); // blue
+                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(g))) * 255.0f) + 0.5f); // green
+                    data[dataIndex++] = (byte)((Math.Max(0.0f, Math.Min(1.0f, ConvertHalfToFloat(r))) * 255.0f) + 0.5f); // red
                     data[dataIndex++] = 255;
 
                     // Is mult 4?

--- a/src/Pfim/dds/Bc7Dds.cs
+++ b/src/Pfim/dds/Bc7Dds.cs
@@ -65,7 +65,7 @@ namespace Pfim.dds
         protected override byte DivSize => 4;
         protected override byte CompressedBytesPerBlock => 16;
 
-        protected override int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
+        protected override unsafe int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
         {
             // I would prefer to use Span, but not sure if I should reference System.Memory in this project
             // copy data instead
@@ -86,7 +86,7 @@ namespace Pfim.dds
                 byte uIndexPrec2 = ms_aInfo[uMode].uIndexPrec2;
                 int i;
                 uint uStartBit = uMode + 1u;
-                int[] P = new int[6];
+                int* P = stackalloc int[6];
                 byte uShape = GetBits(ref uStartBit, ms_aInfo[uMode].uPartitionBits);
                 Debug.Assert(uShape < Constants.BC7_MAX_SHAPES);
 

--- a/src/Pfim/dds/CompressedDds.cs
+++ b/src/Pfim/dds/CompressedDds.cs
@@ -9,7 +9,7 @@ namespace Pfim
     public abstract class CompressedDds : Dds
     {
         private bool _compressed;
-        private MipMapOffset[] _mipMaps = new MipMapOffset[0];
+        private MipMapOffset[] _mipMaps = Array.Empty<MipMapOffset>();
 
         public override MipMapOffset[] MipMaps => _mipMaps;
 

--- a/src/Pfim/dds/Dxt3Dds.cs
+++ b/src/Pfim/dds/Dxt3Dds.cs
@@ -15,7 +15,7 @@
         {
         }
 
-        protected override int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
+        protected override unsafe int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
         {
             /*
              * Strategy for decompression:
@@ -42,7 +42,7 @@
             var c1 = ColorFloatRgb.FromRgb565(color1);
 
             (var i0, var i1) = (c0.As8Bit(), c1.As8Bit());
-            Color888[] colors = new[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
+            Color888* colors = stackalloc Color888[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
 
             for (int i = 0; i < 4; i++)
             {

--- a/src/Pfim/dds/Dxt5Dds.cs
+++ b/src/Pfim/dds/Dxt5Dds.cs
@@ -7,8 +7,6 @@ namespace Pfim
         private const byte PIXEL_DEPTH = 4;
         private const byte DIV_SIZE = 4;
 
-        private readonly byte[] alpha = new byte[8];
-
         public override int BitsPerPixel => 8 * PIXEL_DEPTH;
         public override ImageFormat Format => ImageFormat.Rgba32;
         protected override byte DivSize => DIV_SIZE;
@@ -20,8 +18,10 @@ namespace Pfim
 
         protected override byte PixelDepthBytes => PIXEL_DEPTH;
 
-        protected override int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
+        protected override unsafe int Decode(byte[] stream, byte[] data, int streamIndex, uint dataIndex, uint stride)
         {
+            byte* alpha = stackalloc byte[8];
+
             streamIndex = Bc5Dds.ExtractGradient(alpha, stream, streamIndex);
 
             ulong alphaCodes = stream[streamIndex++];
@@ -43,7 +43,7 @@ namespace Pfim
             var c1 = ColorFloatRgb.FromRgb565(color1);
 
             (var i0, var i1) = (c0.As8Bit(), c1.As8Bit());
-            Color888[] colors = new[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
+            Color888* colors = stackalloc Color888[] { i0, i1, c0.Lerp(c1, 1f / 3).As8Bit(), c0.Lerp(c1, 2f / 3).As8Bit() };
 
             for (int alphaShift = 0; alphaShift < 48; alphaShift += 12)
             {

--- a/src/Pfim/dds/UncompressedDds.cs
+++ b/src/Pfim/dds/UncompressedDds.cs
@@ -12,7 +12,7 @@ namespace Pfim
         private readonly uint? _bitsPerPixel;
         private readonly bool? _rgbSwapped;
         private ImageFormat _format;
-        private MipMapOffset[] _mipMaps = new MipMapOffset[0];
+        private MipMapOffset[] _mipMaps = Array.Empty<MipMapOffset>();
 
 
         internal UncompressedDds(DdsHeader header, PfimConfig config, uint bitsPerPixel, bool rgbSwapped) : base(header, config)

--- a/src/Pfim/targa/CompressedTarga.cs
+++ b/src/Pfim/targa/CompressedTarga.cs
@@ -9,6 +9,8 @@ namespace Pfim
     /// </summary>
     public class CompressedTarga : IDecodeTarga
     {
+        internal static readonly CompressedTarga Instance = new CompressedTarga();
+
         unsafe byte[] FastPass(byte[] data, ArraySegment<byte> arr, TargaHeader header, int stride, long arrPosition)
         {
             var dataLen = header.Height * stride;

--- a/src/Pfim/targa/Targa.cs
+++ b/src/Pfim/targa/Targa.cs
@@ -54,8 +54,8 @@ namespace Pfim
         private static Targa DecodeTarga(Stream str, PfimConfig config, TargaHeader header)
         {
             var targa = (header.IsCompressed)
-                ? (IDecodeTarga) (new CompressedTarga())
-                : new UncompressedTarga();
+                ? (IDecodeTarga) (CompressedTarga.Instance)
+                : UncompressedTarga.Instance;
 
             byte[] data;
             switch (header.Orientation)
@@ -141,7 +141,7 @@ namespace Pfim
             Header.ColorMapDepthBits = 0;
         }
 
-        public MipMapOffset[] MipMaps => new MipMapOffset[0];
+        public MipMapOffset[] MipMaps => Array.Empty<MipMapOffset>();
 
         /// <summary>The raw image data</summary>
         public byte[] Data { get; private set; }

--- a/src/Pfim/targa/UncompressedTarga.cs
+++ b/src/Pfim/targa/UncompressedTarga.cs
@@ -8,6 +8,8 @@ namespace Pfim
     /// </summary>
     public class UncompressedTarga : IDecodeTarga
     {
+        internal static readonly UncompressedTarga Instance = new UncompressedTarga();
+
         /// <summary>Fills data starting from the bottom left</summary>
         public byte[] BottomLeft(Stream str, TargaHeader header, PfimConfig config)
         {


### PR DESCRIPTION
Related to 7632a0a313601b7269f0a3ea481a9e22a00028f9. A caller may use IImageAllocator to amortize allocations for the decoded image buffer when decoding multiple images. However, several other transient allocations are made which create memory traffic. By reducing these transient allocations, we reduce the number of garbage collections required for a performance boost.

We achieve this via a few approaches:
- Use [stackalloc ](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc) to avoid allocating small arrays on the heap. As we are targeting netstandard 2.0 and not 2.1, we lack the ability to access the allocation safely via a Span. Instead, we must unsafely access the allocation via a pointer.
- Use Array.Empty to avoid allocating new, empty arrays for mipmaps.
- Use singletons for the IDecodeTarga classes, as they are stateless.
- In INTColor.ToF16, use out parameters to avoid allocating a small array.

This provides the following benchmark improvements.

----

Before

| Method | Payload   | Mean      | Error     | StdDev    | StdErr    | Median    | Gen0   | Allocated |
|------- |---------- |----------:|----------:|----------:|----------:|----------:|-------:|----------:|
| Pfim   | 32bit.dds |  2.015 us | 0.0112 us | 0.0088 us | 0.0025 us |  2.016 us | 0.0381 |     496 B |
| Pfim   | dxt1.dds  | 38.347 us | 0.7373 us | 0.8491 us | 0.1899 us | 38.417 us | 2.8687 |   36480 B |
| Pfim   | dxt3.dds  | 43.061 us | 0.6037 us | 0.5647 us | 0.1458 us | 42.982 us | 2.8687 |   36480 B |
| Pfim   | dxt5.dds  | 48.005 us | 0.5501 us | 0.5146 us | 0.1329 us | 47.931 us | 2.8687 |   36520 B |

| Method | Payload       | Mean     | Error     | StdDev    | StdErr    | Median   | Gen0   | Allocated |
|------- |-------------- |---------:|----------:|----------:|----------:|---------:|-------:|----------:|
| Pfim   | 24bit-rle.tga | 3.180 us | 0.0371 us | 0.0347 us | 0.0090 us | 3.183 us | 0.0191 |     272 B |
| Pfim   | 32bit-rle.tga | 3.441 us | 0.0266 us | 0.0222 us | 0.0062 us | 3.436 us | 0.0191 |     272 B |
| Pfim   | 32bit.tga     | 2.012 us | 0.0107 us | 0.0100 us | 0.0026 us | 2.012 us | 0.0191 |     272 B |

----

After

| Method | Payload   | Mean      | Error     | StdDev    | StdErr    | Median    | Gen0   | Allocated |
|------- |---------- |----------:|----------:|----------:|----------:|----------:|-------:|----------:|
| Pfim   | 32bit.dds |  2.034 us | 0.0242 us | 0.0226 us | 0.0058 us |  2.032 us | 0.0343 |     472 B |
| Pfim   | dxt1.dds  | 32.704 us | 0.6247 us | 0.6135 us | 0.1534 us | 32.393 us |      - |     456 B |
| Pfim   | dxt3.dds  | 40.869 us | 0.1294 us | 0.1211 us | 0.0313 us | 40.860 us |      - |     456 B |
| Pfim   | dxt5.dds  | 43.623 us | 0.2501 us | 0.2340 us | 0.0604 us | 43.594 us |      - |     456 B |

| Method | Payload       | Mean     | Error     | StdDev    | StdErr    | Median   | Gen0   | Allocated |
|------- |-------------- |---------:|----------:|----------:|----------:|---------:|-------:|----------:|
| Pfim   | 24bit-rle.tga | 2.965 us | 0.0502 us | 0.0469 us | 0.0121 us | 2.973 us | 0.0191 |     248 B |
| Pfim   | 32bit-rle.tga | 3.332 us | 0.0531 us | 0.0443 us | 0.0123 us | 3.329 us | 0.0191 |     248 B |
| Pfim   | 32bit.tga     | 2.367 us | 0.0404 us | 0.0358 us | 0.0096 us | 2.358 us | 0.0191 |     248 B |