### PR TITLE
Implement encoding uncompressed DDS images

### DIFF
--- a/src/Pfim/dds/Dds.cs
+++ b/src/Pfim/dds/Dds.cs
@@ -114,6 +114,18 @@ namespace Pfim
 
         protected abstract void Decode(Stream stream, PfimConfig config);
 
+        internal static void EncodeAsDds(IImage image, Stream stream)
+            => UncompressedDds.Encode(image, stream);
+
+        internal static void EncodeAsDds(IImage image, string path, PfimConfig config)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, config.BufferSize))
+            {
+                EncodeAsDds(image, fs);
+            }
+        }
+
         public void ApplyColorMap()
         {
         }
@@ -124,5 +136,26 @@ namespace Pfim
         {
             _config.Allocator.Return(Data);
         }
+    }
+
+    public static class IImageDdsExtensions
+    {
+        /// <summary>
+        /// Saves the given image to a stream as an uncompressed DDS image.
+        /// </summary>
+        public static void SaveAsDds(this IImage image, Stream stream)
+            => Dds.EncodeAsDds(image, stream);
+
+        /// <summary>
+        /// Saves the given image to the specified file path as an uncompressed DDS image.
+        /// </summary>
+        public static void SaveAsDds(this IImage image, string path, PfimConfig config)
+            => Dds.EncodeAsDds(image, path, config);
+
+        /// <summary>
+        /// Saves the given image to the specified file path as an uncompressed DDS image.
+        /// </summary>
+        public static void SaveAsDds(this IImage image, string path)
+            => Dds.EncodeAsDds(image, path, new PfimConfig());
     }
 }

--- a/src/Pfim/dds/DdsHeader.cs
+++ b/src/Pfim/dds/DdsHeader.cs
@@ -148,6 +148,75 @@ namespace Pfim
     }
 
     /// <summary>
+    /// Specifies the complexity of the surfaces stored.
+    /// </summary>
+    [Flags]
+    public enum DdsCaps : uint
+    {
+        /// <summary>
+        /// Optional; must be used on any file that contains more than one surface (a mipmap, a cubic environment map, or mipmapped volume texture).
+        /// </summary>
+        Complex = 0x8,
+
+        /// <summary>
+        /// Optional; should be used for a mipmap.
+        /// </summary>
+        MipMap = 0x400000,
+
+        /// <summary>
+        /// Required.
+        /// </summary>
+        Texture = 0x1000
+    }
+
+    /// <summary>
+    /// Additional detail about the surfaces stored.
+    /// </summary>
+    [Flags]
+    public enum DdsCaps2 : uint
+    {
+        /// <summary>
+        /// Required for a cube map.
+        /// </summary>
+        Cubemap = 0x200,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapPositiveX = 0x400,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapNegativeX = 0x800,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapPositiveY = 0x1000,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapNegativeY = 0x2000,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapPositiveZ = 0x4000,
+
+        /// <summary>
+        /// Required when these surfaces are stored in a cube map.
+        /// </summary>
+        CubemapNegativeZ = 0x8000,
+
+        /// <summary>
+        /// Required for a volume texture.
+        /// </summary>
+        Volume = 0x200000,
+    }
+
+    /// <summary>
     /// Surface pixel format.
     /// https://msdn.microsoft.com/en-us/library/windows/desktop/bb943984(v=vs.85).aspx
     /// </summary>
@@ -276,8 +345,8 @@ namespace Pfim
                 pixelFormat.BBitMask = *workingBufferPtr++;
                 pixelFormat.ABitMask = *workingBufferPtr++;
 
-                Caps = *workingBufferPtr++;
-                Caps2 = *workingBufferPtr++;
+                Caps = (DdsCaps)(*workingBufferPtr++);
+                Caps2 = (DdsCaps2)(*workingBufferPtr++);
                 Caps3 = *workingBufferPtr++;
                 Caps4 = *workingBufferPtr++;
                 Reserved2 = *workingBufferPtr++;
@@ -337,12 +406,12 @@ namespace Pfim
         /// <summary>
         /// Specifies the complexity of the surfaces stored.
         /// </summary>
-        public uint Caps { get; private set; }
+        public DdsCaps Caps { get; private set; }
 
         /// <summary>
         /// Additional detail about the surfaces stored.
         /// </summary>
-        public uint Caps2 { get; private set; }
+        public DdsCaps2 Caps2 { get; private set; }
 
         /// <summary>
         /// Unused

--- a/src/Pfim/dds/DdsHeader.cs
+++ b/src/Pfim/dds/DdsHeader.cs
@@ -293,8 +293,13 @@ namespace Pfim
 
         DdsPixelFormat pixelFormat;
 
+        internal DdsHeader()
+        {
+            Reserved1 = new uint[11];
+        }
+
         /// <summary>Create header from stream</summary>
-        public DdsHeader(Stream stream, bool skipMagic = false)
+        public DdsHeader(Stream stream, bool skipMagic = false) : this()
         {
             headerInit(stream, skipMagic);
         }
@@ -303,7 +308,7 @@ namespace Pfim
         {
             var headerSize = skipMagic ? SIZE : SIZE + 4;
             byte[] buffer = new byte[headerSize];
-            Reserved1 = new uint[11];
+
             Util.ReadExactly(stream, buffer, 0, headerSize);
 
             fixed (byte* bufferPtr = buffer)
@@ -353,46 +358,74 @@ namespace Pfim
             }
         }
 
+        internal void Encode(BinaryWriter writer)
+        {
+            writer.Write(DDS_MAGIC);
+            writer.Write(SIZE);
+            writer.Write((uint)Flags);
+            writer.Write(Height);
+            writer.Write(Width);
+            writer.Write(PitchOrLinearSize);
+            writer.Write(Depth);
+            writer.Write(MipMapCount);
+            foreach (var r in Reserved1) writer.Write(r);
+
+            writer.Write(32);
+            writer.Write((uint)pixelFormat.PixelFormatFlags);
+            writer.Write((uint)pixelFormat.FourCC);
+            writer.Write(pixelFormat.RGBBitCount);
+            writer.Write(pixelFormat.RBitMask);
+            writer.Write(pixelFormat.GBitMask);
+            writer.Write(pixelFormat.BBitMask);
+            writer.Write(pixelFormat.ABitMask);
+
+            writer.Write((uint)Caps);
+            writer.Write((uint)Caps2);
+            writer.Write(Caps3);
+            writer.Write(Caps4);
+            writer.Write(Reserved2);
+        }
+
         /// <summary>
         /// Size of structure. This member must be set to 124.
         /// </summary>
-        public uint Size { get; private set; }
+        public uint Size { get; internal set; }
 
         /// <summary>
         /// Flags to indicate which members contain valid data. 
         /// </summary>
-        DdsFlags Flags { get;  set; }
+        public DdsFlags Flags { get; internal set; }
 
         /// <summary>
         /// Surface height in pixels
         /// </summary>
-        public uint Height { get; private set; }
+        public uint Height { get; internal set; }
 
         /// <summary>
         /// Surface width in pixels
         /// </summary>
-        public uint Width { get; private set; }
+        public uint Width { get; internal set; }
 
         /// <summary>
         /// The pitch or number of bytes per scan line in an uncompressed texture.
         /// The total number of bytes in the top level texture for a compressed texture.
         /// </summary>
-        public uint PitchOrLinearSize { get; private set; }
+        public uint PitchOrLinearSize { get; internal set; }
 
         /// <summary>
         /// Depth of a volume texture (in pixels), otherwise unused. 
         /// </summary>
-        public uint Depth { get; private set; }
+        public uint Depth { get; internal set; }
 
         /// <summary>
         /// Number of mipmap levels, otherwise unused.
         /// </summary>
-        public uint MipMapCount { get; private set; }
+        public uint MipMapCount { get; internal set; }
 
         /// <summary>
         /// Unused
         /// </summary>
-        public uint[] Reserved1 { get; private set; }
+        public uint[] Reserved1 { get; internal set; }
 
         /// <summary>
         /// The pixel format 
@@ -406,26 +439,26 @@ namespace Pfim
         /// <summary>
         /// Specifies the complexity of the surfaces stored.
         /// </summary>
-        public DdsCaps Caps { get; private set; }
+        public DdsCaps Caps { get; internal set; }
 
         /// <summary>
         /// Additional detail about the surfaces stored.
         /// </summary>
-        public DdsCaps2 Caps2 { get; private set; }
+        public DdsCaps2 Caps2 { get; internal set; }
 
         /// <summary>
         /// Unused
         /// </summary>
-        public uint Caps3 { get; private set; }
+        public uint Caps3 { get; internal set; }
 
         /// <summary>
         /// Unused
         /// </summary>
-        public uint Caps4 { get; private set; }
+        public uint Caps4 { get; internal set; }
 
         /// <summary>
         /// Unused
         /// </summary>
-        public uint Reserved2 { get; private set; }
+        public uint Reserved2 { get; internal set; }
     }
 }

--- a/src/Pfim/dds/UncompressedDds.cs
+++ b/src/Pfim/dds/UncompressedDds.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 
 namespace Pfim
 {
@@ -38,6 +39,139 @@ namespace Pfim
         protected override void Decode(Stream stream, PfimConfig config)
         {
             Data = DataDecode(stream, config);
+        }
+
+        internal static void Encode(IImage image, Stream stream)
+        {
+            if (image == null) throw new ArgumentNullException(nameof(image));
+            if (image.Compressed) throw new InvalidOperationException("Image must be uncompressed before saving.");
+
+            var format = new DdsPixelFormat();
+
+            switch (image.Format)
+            {
+                case ImageFormat.Rgba32:
+                    format.RGBBitCount = 32;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.AlphaPixels | DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x00FF0000;
+                    format.GBitMask = 0x0000FF00;
+                    format.BBitMask = 0x000000FF;
+                    format.ABitMask = 0xFF000000;
+                    break;
+
+                case ImageFormat.Rgb24:
+                    format.RGBBitCount = 24;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x00FF0000;
+                    format.GBitMask = 0x0000FF00;
+                    format.BBitMask = 0x000000FF;
+                    break;
+
+                case ImageFormat.Rgba16:
+                    format.RGBBitCount = 16;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.AlphaPixels | DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x00000F00;
+                    format.GBitMask = 0x000000F0;
+                    format.BBitMask = 0x0000000F;
+                    format.ABitMask = 0x0000F000;
+                    break;
+
+                case ImageFormat.R5g5b5:
+                    format.RGBBitCount = 16;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x00007C00;
+                    format.GBitMask = 0x000003E0;
+                    format.BBitMask = 0x0000001F;
+                    break;
+
+                case ImageFormat.R5g5b5a1:
+                    format.RGBBitCount = 16;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.AlphaPixels | DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x00007C00;
+                    format.GBitMask = 0x000003E0;
+                    format.BBitMask = 0x0000001F;
+                    format.ABitMask = 0x00008000;
+                    break;
+
+                case ImageFormat.R5g6b5:
+                    format.RGBBitCount = 16;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Rgb;
+                    format.RBitMask = 0x0000F800;
+                    format.GBitMask = 0x000007E0;
+                    format.BBitMask = 0x0000001F;
+                    break;
+
+                case ImageFormat.Rgb8:
+                    format.RGBBitCount = 8;
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Luminance;
+                    format.RBitMask = 0x000000FF;
+                    break;
+
+                case ImageFormat.R16f:
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Fourcc;
+                    format.FourCC = CompressionAlgorithm.D3DFMT_R16F;
+                    break;
+
+                case ImageFormat.R32f:
+                    format.PixelFormatFlags = DdsPixelFormatFlags.Fourcc;
+                    format.FourCC = CompressionAlgorithm.D3DFMT_R32F;
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Cannot encode {image.Format} as uncompressed DDS.");
+            }
+
+            var bytesPerPixel = image.BitsPerPixel / 8;
+
+            DdsHeader header = new DdsHeader
+            {
+                PixelFormat = format,
+                Width = (uint)image.Width,
+                Height = (uint)image.Height,
+                MipMapCount = (image.MipMaps != null && image.MipMaps.Length > 0) ? (uint)image.MipMaps.Length + 1 : 0,
+                PitchOrLinearSize = (uint)(image.Width * bytesPerPixel),
+                Flags = DdsFlags.Caps | DdsFlags.Width | DdsFlags.Height | DdsFlags.Pitch | DdsFlags.PixelFormat,
+                Caps = DdsCaps.Texture
+            };
+
+            if (header.MipMapCount > 0)
+            {
+                header.Flags |= DdsFlags.MipMapCount;
+                header.Caps |= DdsCaps.MipMap | DdsCaps.Complex;
+            }
+
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                header.Encode(writer);
+
+                void WriteDataBlock(int lengthInBytes, int width, int height, int offset, int stride)
+                {
+                    var bytesPerRow = width * bytesPerPixel; // No padding. Decoder ignores header pitch.
+
+                    if (bytesPerRow * height == lengthInBytes)
+                    {
+                        writer.Write(image.Data, offset, lengthInBytes);
+                    }
+                    else
+                    {
+                        for (int y = 0; y < height; y++)
+                        {
+                            int rowOffset = offset + y * stride;
+                            writer.Write(image.Data, rowOffset, bytesPerRow);
+                        }
+                    }
+                }
+
+                WriteDataBlock(image.DataLen, image.Width, image.Height, 0, image.Stride);
+
+                if (image.MipMaps != null && image.MipMaps.Length > 0)
+                {
+                    foreach (var mip in image.MipMaps)
+                    {
+                        WriteDataBlock(mip.DataLen, mip.Width, mip.Height, mip.DataOffset, mip.Stride);
+                    }
+                }
+            }
         }
 
         /// <summary>Determine image info from header</summary>

--- a/tests/Pfim.Tests/DdsTests.cs
+++ b/tests/Pfim.Tests/DdsTests.cs
@@ -479,5 +479,127 @@ namespace Pfim.Tests
             Assert.Equal(64, image.Height);
             Assert.Equal(64, image.Width);
         }
+
+        private static void ValidatePixelGrid(
+            byte[] origData, int origW, int origH, int origStride, int origOffset,
+            byte[] loadData, int loadW, int loadH, int loadStride, int loadOffset,
+            int bytesPerPixel, string levelName)
+        {
+            for (int y = 0; y < origH; y++)
+            {
+                // Calculate starting indices by incorporating the respective layer offsets and row strides
+                int origRowIndex = origOffset + (y * origStride);
+                int loadRowIndex = loadOffset + (y * loadStride);
+
+                for (int x = 0; x < origW; x++)
+                {
+                    int origPixelIndex = origRowIndex + (x * bytesPerPixel);
+                    int loadPixelIndex = loadRowIndex + (x * bytesPerPixel);
+
+                    for (int ch = 0; ch < bytesPerPixel; ch++)
+                    {
+                        byte expectedByte = origData[origPixelIndex + ch];
+                        byte actualByte = loadData[loadPixelIndex + ch];
+
+                        if (expectedByte != actualByte)
+                        {
+                            Assert.Fail(
+                                $"[{levelName}] Mismatch at coordinate ({x},{y}), Channel Byte Offset {ch}. Expected: {expectedByte}, Got: {actualByte}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("16-bit-float.dds")]
+        [InlineData("24-bit-uncompressed-bgr-odd.dds")]
+        [InlineData("24-bit-uncompressed-odd.dds")]
+        [InlineData("32-bit-float.dds")]
+        [InlineData("32-bit-uncompressed-odd.dds")]
+        [InlineData("32-bit-uncompressed.dds")]
+        [InlineData("Antenna_Metal_0_Normal.dds")]
+        [InlineData("bc4-simple.dds")]
+        [InlineData("bc5-simple-snorm.dds")]
+        [InlineData("bc5-simple.dds")]
+        [InlineData("dds_a1r5g5b5.dds")]
+        [InlineData("dds_A4R4G4B4.dds")]
+        [InlineData("dds_A8B8G8R8.dds")]
+        [InlineData("dds_R5G6B5.dds")]
+        [InlineData("dds_R8G8B8.dds")]
+        [InlineData("dxt1-alpha.dds")]
+        [InlineData("dxt1-simple.dds")]
+        [InlineData("dxt3-simple.dds")]
+        [InlineData("dxt5-simple-1x1.dds")]
+        [InlineData("dxt5-simple-odd.dds")]
+        [InlineData("dxt5-simple.dds")]
+        [InlineData("TestVolume_Noise3D.dds")]
+        [InlineData("wose_BC1_UNORM.dds")]
+        [InlineData("24-bit-odd.tga")]
+        [InlineData("CBW8.tga")]
+        [InlineData("CCM8.tga")]
+        [InlineData("colormap-odd.tga")]
+        [InlineData("CTC16.tga")]
+        [InlineData("CYA.tga")]
+        [InlineData("DSCN1910_24bpp_uncompressed_10_2.tga")]
+        [InlineData("DSCN1910_24bpp_uncompressed_10_3.tga")]
+        [InlineData("flag_t32.tga")]
+        [InlineData("large-top-left.tga")]
+        [InlineData("marbles.tga")]
+        [InlineData("marbles2.tga")]
+        [InlineData("rgb24_top_left_colormap.tga")]
+        [InlineData("rgb24_top_left.tga")]
+        [InlineData("rgb32_top_left_rle_colormap.tga")]
+        [InlineData("tiny-rect.tga")]
+        [InlineData("true-24-bottom-right.tga")]
+        [InlineData("true-24-large.tga")]
+        [InlineData("true-24-rle.tga")]
+        [InlineData("true-24.tga")]
+        [InlineData("true-32-mixed.tga")]
+        [InlineData("true-32-rle-large.tga")]
+        [InlineData("true-32-rle.tga")]
+        [InlineData("true-32.tga")]
+        public void SaveUncompressedDds(string fileName)
+        {
+            var path = Path.Combine("data", fileName);
+            var original = Pfimage.FromFile(path);
+            var originalMipCount = original.MipMaps?.Length ?? 0;
+
+            var ms = new MemoryStream();
+            original.SaveAsDds(ms);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var loaded = Pfimage.FromStream(ms);
+            Assert.Equal(original.Width, loaded.Width);
+            Assert.Equal(original.Height, loaded.Height);
+            Assert.Equal(original.BitsPerPixel, loaded.BitsPerPixel);
+            Assert.Equal(original.Format, loaded.Format);
+            Assert.Equal(original.MipMaps?.Length, loaded.MipMaps?.Length);
+
+            ValidatePixelGrid(
+                original.Data, original.Width, original.Height, original.Stride, 0,
+                loaded.Data, loaded.Width, loaded.Height, loaded.Stride, 0,
+                original.BitsPerPixel / 8, levelName: "Base Layer (Mip 0)"
+            );
+
+            if (originalMipCount > 0)
+            {
+                for (int m = 0; m < originalMipCount; m++)
+                {
+                    var origMip = original.MipMaps[m];
+                    var loadMip = loaded.MipMaps[m];
+
+                    Assert.Equal(origMip.Width, loadMip.Width);
+                    Assert.Equal(origMip.Height, loadMip.Height);
+
+                    ValidatePixelGrid(
+                        original.Data, origMip.Width, origMip.Height, origMip.Stride, origMip.DataOffset,
+                        loaded.Data, loadMip.Width, loadMip.Height, loadMip.Stride, loadMip.DataOffset,
+                        original.BitsPerPixel / 8, levelName: $"Mip Level {m + 1}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/tests/Pfim.Tests/DdsTests.cs
+++ b/tests/Pfim.Tests/DdsTests.cs
@@ -535,7 +535,7 @@ namespace Pfim.Tests
         [InlineData("dxt5-simple-odd.dds")]
         [InlineData("dxt5-simple.dds")]
         [InlineData("TestVolume_Noise3D.dds")]
-        [InlineData("wose_BC1_UNORM.dds")]
+        [InlineData("wose_BC1_UNORM.DDS")]
         [InlineData("24-bit-odd.tga")]
         [InlineData("CBW8.tga")]
         [InlineData("CCM8.tga")]


### PR DESCRIPTION
Hello,

I've implemented encoding uncompressed DDS images as extensions for the `IImage` interface:

```csharp
public static void SaveAsDds(this IImage image, Stream stream)
public static void SaveAsDds(this IImage image, string path, PfimConfig config)
public static void SaveAsDds(this IImage image, string path)
```

The source image must be uncompressed but doesn't have to be a DDS image. The result is an encoded uncompressed DDS image (including mip maps).

Two things to consider:

1. I've added `DdsCaps` and `DdsCaps2` enums and changed the type of the `DdsHeader` properties from `uint` to the new respective enum. If this breaking change is problematic, it can be reverted.
2. The data is always written unpadded, since the decoder assumes a tight layout and ignores the pitch from the header.

I've added round trip tests for all the test images that can be loaded.

Cheers.